### PR TITLE
service: hidden parameters to the API addition

### DIFF
--- a/src/invenio-search-js/invenioSearch.module.js
+++ b/src/invenio-search-js/invenioSearch.module.js
@@ -155,7 +155,7 @@
       }
 
       invenioSearchAPI
-        .search(vm.invenioSearchArgs)
+        .search(vm.invenioSearchArgs, vm.invenioSearchHiddenParams)
         .then(successfulRequest, erroredRequest)
         .finally(clearRequest);
     }
@@ -232,6 +232,7 @@
    *    Usage:
    *    <invenio-search
    *     search-endpoint='SEARCH_PROVIDER_URL'
+   *     search-hidden-params='{"collection": "Collection"}'>
    *     search-extra-params='{"page": 2, "size": 5}'>
    *        ... Any children directives
    *    </invenio-search>
@@ -263,6 +264,10 @@
       var urlParams = {
         params: vm.invenioSearchGetUrlArgs()
       };
+
+      vm.invenioSearchHiddenParams = JSON.parse(
+        attrs.searchHiddenParams  || '{}'
+      );
 
       // Update arguments
       vm.invenioSearchArgs = angular.merge(
@@ -1218,7 +1223,7 @@
      * @param {Object} args - The search request parameters.
      * @returns {service} promise
      */
-    function search(args) {
+    function search(args, hidden) {
 
       // Initialize the promise
       var deferred = $q.defer();
@@ -1243,8 +1248,13 @@
         deferred.reject(response);
       }
 
+      // Place all parameters together
+      var params = angular.merge({}, args);
+      // extend parameters with the hidden params
+      params.params = angular.merge(params.params, hidden || {});
+
       // Make the request
-      $http(args).then(
+      $http(params).then(
         success,
         error
       );

--- a/test/unit/invenio-search-js/directives/searchBarSpec.js
+++ b/test/unit/invenio-search-js/directives/searchBarSpec.js
@@ -46,14 +46,16 @@ describe('Check earchbar directive', function() {
 
       scope = $rootScope;
 
-      template = '<invenio-search search-endpoint="/api"> ' +
+      template = '<invenio-search search-endpoint="/api" ' +
+       'search-hidden-params=\'{"hero": "jessicajones"}\'> ' +
        '<invenio-search-bar template="src/invenio-search-js/templates/searchBar.html" ' +
        'placeholder="Type something"></invenio-search-bar>' +
        '</invenio-search>';
 
       // Expect a request
-      $httpBackend.whenGET('/api?page=1&q=jarvis:call+Jessica+Jones&size=20').respond(200, {success: true});
-      $httpBackend.whenGET('/api?page=1&q=jarvis:+get+to+the+choppa&size=20').respond(200, {success: true});
+      //
+      $httpBackend.whenGET('/api?hero=jessicajones&page=1&q=jarvis:call+Jessica+Jones&size=20').respond(200, {success: true});
+      $httpBackend.whenGET('/api?hero=jessicajones&page=1&q=jarvis:+get+to+the+choppa&size=20').respond(200, {success: true});
 
       // Compile
       template = $compile(template)(scope);
@@ -82,5 +84,13 @@ describe('Check earchbar directive', function() {
     );
 
     $httpBackend.flush();
+  });
+
+  it('should not have hidden parameters in the query', function() {
+    expect(scope.vm.invenioSearchArgs.params.hero).to.be.undefined;
+  });
+
+  it('should have hidden parameter', function() {
+    expect(scope.vm.invenioSearchHiddenParams.hero).to.be.equal('jessicajones');
   });
 });


### PR DESCRIPTION
* Adds an attribute `search-hidden-params` which allows you to pass an
  object to the API without been visible to the URL. (closes #37)

Signed-off-by: Harris Tzovanakis <me@drjova.com>