### PR TITLE
controllers: reset page on new query adddition

### DIFF
--- a/src/invenio-search-js/invenioSearch.module.js
+++ b/src/invenio-search-js/invenioSearch.module.js
@@ -239,6 +239,10 @@
      */
     function invenioSearchRequestSearch(event, params) {
       if(!angular.equals(vm.invenioSearchCurrentArgs.params, params)) {
+        // If the page is the same and the query different reset it
+        if (vm.invenioSearchCurrentArgs.params.page === params.page) {
+          params.page = 1;
+        }
         // Merge
         angular.forEach(params, function(value, key) {
           vm.invenioSearchCurrentArgs.params[key] = value;
@@ -249,7 +253,7 @@
           vm.invenioSearchCurrentArgs.params
         );
 
-        //// Update url
+        // Update url
         invenioSearchHandler.set(vm.invenioSearchCurrentArgs.params);
         // Update searcbox query
         vm.userQuery = vm.invenioSearchArgs.q;

--- a/test/unit/invenio-search-js/directives/searchPaginationSpec.js
+++ b/test/unit/invenio-search-js/directives/searchPaginationSpec.js
@@ -47,6 +47,8 @@ describe('Check search pagination directive', function() {
       scope = $rootScope;
 
       $httpBackend.whenGET('/api?page=1&size=20').respond(200, {success: true});
+      $httpBackend.whenGET('/api?page=7&q=jarvis:+hello%3F%3F&size=20').respond(200, {success: true});
+      $httpBackend.whenGET('/api?page=1&q=jarvis:+hello%3F%3F&size=20').respond(200, {success: true});
       $httpBackend.whenGET('/api?page=7&q=jarvis:+hello+do+you+here+me%3F&size=20').respond(200, {success: true});
       $httpBackend.whenGET('/api?page=1&q=jarvis:+hello+do+you+here+me%3F&size=3').respond(200, {success: true});
       $httpBackend.whenGET('/api?page=3&q=jarvis:+hello+do+you+here+me%3F&size=3').respond(200, {success: true});
@@ -216,5 +218,17 @@ describe('Check search pagination directive', function() {
     };
     scope.$digest();
     expect(template.find('li').eq(5).text().trim()).to.be.equal('7');
+  });
+
+  it('should reset page parameter if any of args changed but page', function() {
+    scope.vm.invenioSearchArgs = {
+      page: 7,
+      size: 20,
+      q: 'jarvis: hello do you here me?'
+    };
+    scope.vm.invenioSearchArgs = {
+      q: 'jarvis: hello??'
+    };
+    expect(scope.vm.invenioSearchCurrentArgs.params.page).to.be.equal(1);
   });
 });


### PR DESCRIPTION
* FIX Fixes an issue with page parameter which is kept when a new search
  requested. (closes #59)

Signed-off-by: Harris Tzovanakis <me@drjova.com>