### PR TITLE
search: deselection of facet fix

### DIFF
--- a/src/invenio-search-js/invenioSearch.module.js
+++ b/src/invenio-search-js/invenioSearch.module.js
@@ -761,8 +761,14 @@
           // Add the value in the list
           scope.handler[key].push(value);
         } else {
-          // Just remove it from the list
-          scope.handler[key].splice(index, 1);
+          // When the params are populated from a direct link, 
+          // the type is a string, not a list, so splice will fail.
+          if (typeof scope.handler[key] === "string") {
+            scope.handler[key] = [];
+          } else {
+            // Just remove it from the list
+            scope.handler[key].splice(index, 1);
+          }
         }
         // Update Args
         var params = {};


### PR DESCRIPTION
* FIX Fixes errors that occurred when deselecting facets on page change
  or when a page with preselected facets have been accessed. 
  (closes #66) (closes #67) 

Signed-off-by: Eamonn Maguire <eamonnmag@gmail.com>