### PR TITLE
docs: fix demo instructions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,5 +28,6 @@ Invenio Search JS.
 
 - Harris Tzovanakis <me@drjova.com>
 - Jiri Kuncar <jiri.kuncar@cern.ch>
+- Joao Goncalves <jsvgoncalves@gmail.com>
 - Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
 - Nikos Filippakis <nikolaos.filippakis@cern.ch>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation
 Demo
 ----
 
-    $ cd example; npm install; cd ..
+    $ pushd examples/simple; npm install; popd
     $ npm run-script demo
 
 Navigate to `http://localhost:8000` to see the `demo`.


### PR DESCRIPTION
* Points to the correct examples dir at `examples/simple`.