### PR TITLE
Fix range ui issues

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 =========================
- Invenio-Search-JS v1.3.0
+ Invenio-Search-JS v1.3.1
 =========================
 
-Invenio-Search-JS v1.3.0 was released on 28 September, 2017.
+Invenio-Search-JS v1.3.1 was released on 5 October 2017.
 
 About
 -----

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invenio-search-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Javascript search components for Invenio-Search",
   "author": {
     "name": "CERN",


### PR DESCRIPTION
@drjova I am not a fan of these changes, but the only easy way I see to stop the infinite loop, that is breaking the `Reset` button is to perform brush redraws only if the user selection (range) as really changed. That's why all that ifs.
Let me know if you have better ideas.

I have created an issue for the refactoring: https://github.com/inveniosoftware/invenio-search-js/issues/104