### PR TITLE
global: add functions to determine if any facet option was selected and to reset facets

### DIFF
--- a/src/invenio-search-js/directives/invenioSearchFacets.js
+++ b/src/invenio-search-js/directives/invenioSearchFacets.js
@@ -108,6 +108,17 @@ function invenioSearchFacets() {
     }
 
     /**
+      * Unselect/Reset options user selected in a facet
+      */
+    function resetSelection(key) {
+      var params = {};
+      scope.handler[key] = [];
+      params[key] = angular.copy(scope.handler[key]);
+      // Update the params args
+      scope.$broadcast('invenio.search.params.change', params);
+    }
+
+    /**
       * Order the aggregations if a custom order is provided
       * @memberof link
       * @function orderAggregations
@@ -141,6 +152,8 @@ function invenioSearchFacets() {
     scope.handleClick = handleClick;
     // Return the values
     scope.getValues = getValues;
+    //Reset selected facets
+    scope.resetSelection = resetSelection;
   }
 
   /**

--- a/src/invenio-search-js/directives/invenioSearchFacets.js
+++ b/src/invenio-search-js/directives/invenioSearchFacets.js
@@ -119,6 +119,13 @@ function invenioSearchFacets() {
     }
 
     /**
+      * Return true if any of the options in a facet is selected
+      */
+    function isFacetSelected(key) {
+      return scope.handler[key] !== undefined && scope.handler[key].length !== 0 ? true : false;
+    }
+
+    /**
       * Order the aggregations if a custom order is provided
       * @memberof link
       * @function orderAggregations
@@ -154,6 +161,8 @@ function invenioSearchFacets() {
     scope.getValues = getValues;
     //Reset selected facets
     scope.resetSelection = resetSelection;
+    // Check if facet options are selected
+    scope.isFacetSelected = isFacetSelected;
   }
 
   /**


### PR DESCRIPTION
`isFacetSelected()` and `resetSelection()` are needed to [reset check boxes selected in a facet in inspire-next](https://github.com/inspirehep/inspirehep-search-js/pull/51/files#diff-d5d4c58c04fa9a3eb91ad889c62407bdR4)

Signed-off-by: Dinika <dinika.saxena@cern.ch> 