### PR TITLE
global: expose method to determine whether a range is selected

### DIFF
--- a/src/invenio-search-js/directives/invenioSearchRange.js
+++ b/src/invenio-search-js/directives/invenioSearchRange.js
@@ -111,6 +111,13 @@ function invenioSearchRange(invenioSearchRangeFactory, $window) {
     }
 
     /**
+     * Determine if the user selected a range
+     */
+    function isRangeSelected() {
+        return options.selectionRange === undefined ? false : true;
+    }
+
+    /**
       * Render a new histogram
       * @memberof link
       */
@@ -152,6 +159,7 @@ function invenioSearchRange(invenioSearchRangeFactory, $window) {
       angular.element($window).bind('resize', updateRange);
     }
     scope.resetRangeSelection = resetUserSelection;
+    scope.isRangeSelected = isRangeSelected;
   }
 
   /**


### PR DESCRIPTION
This method was needed to implement a [reset feature in inspire-next ](https://github.com/inspirehep/inspirehep-search-js/pull/51/files#diff-4e3b97edd0890904e471acc6f809f126R3)to check if the user has selected a range of years. If the range is selected than the option to reset it is displayed, otherwise, not.

Signed-off-by: Dinika <dinika.saxena@cern.ch>